### PR TITLE
Fix key listener registration

### DIFF
--- a/src/CarPhysics.tsx
+++ b/src/CarPhysics.tsx
@@ -32,7 +32,7 @@ const CarPhysics = forwardRef<Mesh, {}>((_, ref) => {
       window.removeEventListener("keydown", down);
       window.removeEventListener("keyup", up);
     };
-  }, [keys]);
+  }, []);
 
   // Create a dynamic box body
   const [boxRef, api] = useBox<Mesh>(


### PR DESCRIPTION
## Summary
- ensure key listeners on CarPhysics register only once

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6852336fc6088327831611620b46b635